### PR TITLE
Fix syntax error in tokenMap

### DIFF
--- a/packages/reader-alignments-mode/src/AlignmentsModeReader.vue
+++ b/packages/reader-alignments-mode/src/AlignmentsModeReader.vue
@@ -230,7 +230,7 @@
           (map, tokenRecord) => ({
             ...map,
             [tokenRecord.token]: [
-              ...[map[tokenRecord.token] || []],
+              ...(map[tokenRecord.token] || []),
               tokenRecord.record,
             ],
           }),


### PR DESCRIPTION
Fixes a syntax error introduced in `0.0.10` that added an empty array (rather than appending an item to an empty array)