### PR TITLE
Switch from independent versioning and add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## 0.2.0 (2020-11-11)
+
+### Features
+- Switch to unified package versioning.  All `@scaife-viewer` packages now share a unified version number.
+- Add CHANGELOG.md to track changes
+
+## Previous Releases
+View Pull Requests from previous releases [here](https://github.com/scaife-viewer/frontend/pulls?q=is%3Apr+is%3Aclosed+created%3A%3C2020-11-11)

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent"
+  "version": "0.2.0"
 }


### PR DESCRIPTION
The SV dev team decided that a unified version number and changelog would make it easier to keep up with changes to the project.