### PR TITLE
Add configuration options to dictionary entries widget

### DIFF
--- a/packages/widget-dictionary-entries/README.md
+++ b/packages/widget-dictionary-entries/README.md
@@ -7,3 +7,7 @@ A widget that displays dictionary entries.
 `$scaife.config.dictionaryEntries.showCitationResolutionHint`:
 
 Set to `false` to hide tooltip showing citation resolution message.
+
+`$scaife.config.dictionaryEntries.resolveUsingNormalizedLemmas`:
+
+Set to `true` to include `normalizeLemmas: true` when resolving entries by lemma.

--- a/packages/widget-dictionary-entries/README.md
+++ b/packages/widget-dictionary-entries/README.md
@@ -11,3 +11,7 @@ Set to `false` to hide tooltip showing citation resolution message.
 `$scaife.config.dictionaryEntries.resolveUsingNormalizedLemmas`:
 
 Set to `true` to include `normalizeLemmas: true` when resolving entries by lemma.
+
+`$scaife.config.dictionaryEntries.selectDictionaries`:
+
+Set to `false` to disable selection of dictionaries.

--- a/packages/widget-dictionary-entries/README.md
+++ b/packages/widget-dictionary-entries/README.md
@@ -1,3 +1,9 @@
 # widget-dictionary-entries
 
 A widget that displays dictionary entries.
+
+## Configuration options
+
+`$scaife.config.dictionaryEntries.showCitationResolutionHint`:
+
+Set to `false` to hide tooltip showing citation resolution message.

--- a/packages/widget-dictionary-entries/src/DictionaryEntries.vue
+++ b/packages/widget-dictionary-entries/src/DictionaryEntries.vue
@@ -19,7 +19,9 @@
             {{ headword }}
             <span
               title="Indicates that the entry is resolved solely via citation"
-              v-if="showCitationResolutionHint && isResolvedByCitationOnly(entries)"
+              v-if="
+                showCitationResolutionHint && isResolvedByCitationOnly(entries)
+              "
               >*</span
             >
           </span>

--- a/packages/widget-dictionary-entries/src/DictionaryEntries.vue
+++ b/packages/widget-dictionary-entries/src/DictionaryEntries.vue
@@ -19,7 +19,7 @@
             {{ headword }}
             <span
               title="Indicates that the entry is resolved solely via citation"
-              v-if="isResolvedByCitationOnly(entries)"
+              v-if="showCitationResolutionHint && isResolvedByCitationOnly(entries)"
               >*</span
             >
           </span>
@@ -107,6 +107,11 @@
           byHeadword.set(key, lookupValue);
         });
         return byHeadword;
+      },
+      showCitationResolutionHint() {
+        const fallback = true;
+        const config = this.$scaife.config.dictionaryEntries;
+        return config ? config.showCitationResolutionHint : fallback;
       },
     },
     apollo: {

--- a/packages/widget-dictionary-entries/src/DictionaryEntriesWidget.vue
+++ b/packages/widget-dictionary-entries/src/DictionaryEntriesWidget.vue
@@ -82,6 +82,11 @@
           ? this.candidateLemmaEntries[0].urn
           : null;
       },
+      resolveUsingNormalizedLemmas() {
+        const fallback = false;
+        const config = this.$scaife.config.dictionaryEntries;
+        return config ? config.resolveUsingNormalizedLemmas : fallback;
+      }
     },
     apollo: {
       lemmaEntries: {
@@ -91,8 +96,8 @@
         // TODO: Tweak query to include dictionary.urn
         // only if `dictionaryEntriesMode` is true
         query: gql`
-          query DictionaryEntries($lemma: String!) {
-            dictionaryEntries(lemma: $lemma) {
+          query DictionaryEntries($lemma: String!, $normalizeLemmas: Boolean!) {
+            dictionaryEntries(lemma: $lemma, normalizeLemmas: $normalizeLemmas ) {
               edges {
                 node {
                   id
@@ -107,7 +112,7 @@
           }
         `,
         variables() {
-          return { lemma: `${this.lemmas[0]}` };
+          return { lemma: `${this.lemmas[0]}`, normalizeLemmas: this.resolveUsingNormalizedLemmas, };
         },
         update(data) {
           return data.dictionaryEntries.edges.map(e => e.node);

--- a/packages/widget-dictionary-entries/src/DictionaryEntriesWidget.vue
+++ b/packages/widget-dictionary-entries/src/DictionaryEntriesWidget.vue
@@ -86,7 +86,7 @@
         const fallback = false;
         const config = this.$scaife.config.dictionaryEntries;
         return config ? config.resolveUsingNormalizedLemmas : fallback;
-      }
+      },
     },
     apollo: {
       lemmaEntries: {
@@ -97,7 +97,10 @@
         // only if `dictionaryEntriesMode` is true
         query: gql`
           query DictionaryEntries($lemma: String!, $normalizeLemmas: Boolean!) {
-            dictionaryEntries(lemma: $lemma, normalizeLemmas: $normalizeLemmas ) {
+            dictionaryEntries(
+              lemma: $lemma
+              normalizeLemmas: $normalizeLemmas
+            ) {
               edges {
                 node {
                   id
@@ -112,7 +115,10 @@
           }
         `,
         variables() {
-          return { lemma: `${this.lemmas[0]}`, normalizeLemmas: this.resolveUsingNormalizedLemmas, };
+          return {
+            lemma: `${this.lemmas[0]}`,
+            normalizeLemmas: this.resolveUsingNormalizedLemmas,
+          };
         },
         update(data) {
           return data.dictionaryEntries.edges.map(e => e.node);

--- a/packages/widget-dictionary-entries/src/DictionaryEntry.vue
+++ b/packages/widget-dictionary-entries/src/DictionaryEntry.vue
@@ -34,17 +34,19 @@
             </div>
           </div>
         </div>
-        <div class="dictionary-label-divider" />
-        <CustomSelect
-          v-if="siblingEntryValues.length > 0"
-          class="sibling-entry-select"
-          v-model="selectedEntryValue"
-          :options="siblingEntryValues"
-          placeholder="Select an alignment..."
-        />
-        <Attribution v-else>
-          {{ entry.dictionary.label }}
-        </Attribution>
+        <template v-if="selectDictionaries">
+          <div class="dictionary-label-divider" />
+          <CustomSelect
+            v-if="siblingEntryValues.length > 0"
+            class="sibling-entry-select"
+            v-model="selectedEntryValue"
+            :options="siblingEntryValues"
+            placeholder="Select an alignment..."
+          />
+          <Attribution v-else>
+            {{ entry.dictionary.label }}
+          </Attribution>
+        </template>
       </div>
     </div>
     <LoaderBall v-else-if="$apollo.queries.entries.loading" />
@@ -198,6 +200,11 @@
             return { title, value: sibling.urn };
           });
       },
+      selectDictionaries() {
+        const fallback = true;
+        const config = this.$scaife.config.dictionaryEntries;
+        return config ? config.selectDictionaries : fallback;
+      }
     },
     apollo: {
       // NOTE: this query gets all possible senses and everything needed

--- a/packages/widget-dictionary-entries/src/DictionaryEntry.vue
+++ b/packages/widget-dictionary-entries/src/DictionaryEntry.vue
@@ -204,7 +204,7 @@
         const fallback = true;
         const config = this.$scaife.config.dictionaryEntries;
         return config ? config.selectDictionaries : fallback;
-      }
+      },
     },
     apollo: {
       // NOTE: this query gets all possible senses and everything needed

--- a/src/main.js
+++ b/src/main.js
@@ -89,6 +89,7 @@ Vue.use(SkeletonPlugin, {
     },
     dictionaryEntries: {
       showCitationResolutionHint: true,
+      resolveUsingNormalizedLemmas: false,
     },
     pageTitle: title => `SV Demo | ${title}`,
   },

--- a/src/main.js
+++ b/src/main.js
@@ -87,6 +87,9 @@ Vue.use(SkeletonPlugin, {
     citationSchemeMap: {
       book: 'Books',
     },
+    dictionaryEntries: {
+      showCitationResolutionHint: true,
+    },
     pageTitle: title => `SV Demo | ${title}`,
   },
 });

--- a/src/main.js
+++ b/src/main.js
@@ -90,6 +90,7 @@ Vue.use(SkeletonPlugin, {
     dictionaryEntries: {
       showCitationResolutionHint: true,
       resolveUsingNormalizedLemmas: false,
+      selectDictionaries: true,
     },
     pageTitle: title => `SV Demo | ${title}`,
   },


### PR DESCRIPTION
See `README.md` for details; allows the widget to have slightly different behavior for Beyond Translation than in Scholarly Editions.