### PR TITLE
Follow ups to ROI / Scholia, v2 #77

### DIFF
--- a/packages/reader-image-mode/src/ImageViewer.vue
+++ b/packages/reader-image-mode/src/ImageViewer.vue
@@ -272,9 +272,13 @@
             });
 
             // eslint-disable-next-line no-new
+            const userData = {
+              roi,
+            };
             new OpenSeadragon.MouseTracker({
               element,
-              clickHandler: () => {
+              clickHandler: event => {
+                debugger;
                 this.$store.dispatch(
                   `${MODULE_NS}/${HIGHLIGHT_TRANSCRIPTION}`,
                   {
@@ -282,6 +286,7 @@
                   },
                 );
               },
+              userData,
             });
           }),
         );

--- a/packages/reader-image-mode/src/ImageViewer.vue
+++ b/packages/reader-image-mode/src/ImageViewer.vue
@@ -180,9 +180,10 @@
         handler() {
           const line = this.$store.state[MODULE_NS].selectedLine;
 
-          if (line) {
-            this.$data.showClickableRois = false;
-          }
+          // if (line) {
+          //   debugger;
+          //   this.$data.showClickableRois = false;
+          // }
 
           this.clearRoiOverlays();
           this.drawRoiOverlays();

--- a/packages/widget-commentary/src/CommentaryWidget.vue
+++ b/packages/widget-commentary/src/CommentaryWidget.vue
@@ -319,8 +319,8 @@
     apollo: {
       lines: {
         query: gql`
-          query Scholia($urn: String!) {
-            textAnnotations(reference: $urn) {
+          query Commentaries($urn: String!) {
+            textAnnotations(reference: $urn, kind: "commentary") {
               edges {
                 node {
                   id

--- a/packages/widget-commentary/src/CommentaryWidget2.vue
+++ b/packages/widget-commentary/src/CommentaryWidget2.vue
@@ -329,8 +329,12 @@
     apollo: {
       lines: {
         query: gql`
-          query Scholia($urn: String!, $collectionUrn: ID) {
-            textAnnotations(reference: $urn, collection_Urn: $collectionUrn) {
+          query Commentaries($urn: String!, $collectionUrn: ID) {
+            textAnnotations(
+              reference: $urn,
+              collection_Urn: $collectionUrn,
+              kind: "commentary"
+            ) {
               edges {
                 node {
                   id

--- a/packages/widget-scholia/src/ScholiaWidget.vue
+++ b/packages/widget-scholia/src/ScholiaWidget.vue
@@ -39,7 +39,11 @@
       lines: {
         query: gql`
           query Scholia($urn: String!, $collectionUrn: ID) {
-            textAnnotations(reference: $urn, collection_Urn: $collectionUrn) {
+            textAnnotations(
+              reference: $urn,
+              collection_Urn: $collectionUrn,
+              kind: "scholia"
+            ) {
               edges {
                 node {
                   id


### PR DESCRIPTION
#77 got merged without a couple of commits related to ROI click handlers.

I'm also including a fix so that the "Textual Notes" widget only shows "commentary" text annotations and the scholia widget scholia, etc.